### PR TITLE
Prevent panic on type conversion

### DIFF
--- a/pubKeyRep.go
+++ b/pubKeyRep.go
@@ -92,7 +92,9 @@ func newPubKeyFromDnsTxt(selector, domain string) (*pubKeyRep, verifyOutput, err
 				return nil, PERMFAIL, ErrVerifyBadKey
 			}
 			pk, err := x509.ParsePKIXPublicKey(un64)
-			pkr.PubKey = *pk.(*rsa.PublicKey)
+			if pk, ok := pk.(*rsa.PublicKey); ok {
+				pkr.PubKey = *pk
+			}
 		case "s":
 			t := strings.Split(strings.ToLower(val), ":")
 			for _, tt := range t {


### PR DESCRIPTION
Hello, thanks for your package! I'm using it in spam filter service.
On one of mail servers, my service periodically panics:
```
Dec  2 17:36:42 e-mail: panic: interface conversion: interface {} is nil, not *rsa.PublicKey
Dec  2 17:36:42 e-mail: goroutine 55532 [running]:
Dec  2 17:36:42 e-mail: github.com/toorop/go-dkim.newPubKeyFromDnsTxt(0xc42042f222, 0x4, 0xc42042f205, 0x10, 0x3, 0x484d1b, 0xc420014070, 0xc420014000)
Dec  2 17:36:42 e-mail: /go/src/github.com/toorop/go-dkim/pubKeyRep.go:95 +0x10fa
Dec  2 17:36:42 e-mail: github.com/toorop/go-dkim.Verify(0xc42032fc38, 0xc420076230, 0x2, 0xc42056a990)
Dec  2 17:36:42 e-mail: /go/src/github.com/toorop/go-dkim/dkim.go:214 +0x148
Dec  2 17:36:42 e-mail: main.verifyDKIM(0xc420516000, 0x4944, 0x5c30, 0x0, 0x0, 0x5874e0)
```