### PR TITLE
Replace LF with CRLF

### DIFF
--- a/dkim.go
+++ b/dkim.go
@@ -534,8 +534,11 @@ func getHeadersList(rawHeader *[]byte) (*list.List, error) {
 
 // getHeadersBody return headers and body
 func getHeadersBody(email *[]byte) ([]byte, []byte, error) {
-	// TODO: \n -> \r\n
-	parts := bytes.SplitN(*email, []byte{13, 10, 13, 10}, 2)
+
+	// \n -> \r\n
+	substitutedEmail := bytes.Replace(*email, []byte{10}, []byte{13, 10}, -1)
+
+	parts := bytes.SplitN(substitutedEmail, []byte{13, 10, 13, 10}, 2)
 	if len(parts) != 2 {
 		return []byte{}, []byte{}, ErrBadMailFormat
 	}

--- a/dkim.go
+++ b/dkim.go
@@ -534,7 +534,6 @@ func getHeadersList(rawHeader *[]byte) (*list.List, error) {
 
 // getHeadersBody return headers and body
 func getHeadersBody(email *[]byte) ([]byte, []byte, error) {
-
 	// \n -> \r\n
 	substitutedEmail := bytes.Replace(*email, []byte{10}, []byte{13, 10}, -1)
 


### PR DESCRIPTION
Emails fail validation due to "bad mail format", which is caused by loss of CRLFs somewhere in the data pipeline when a raw email is downloaded for testing this library. This PR attempts to fix this problem by replacing all LFs with CRLFs as was noted in the TODO tag on line 537 of dkim.go

While I don't completely understand where in the pipeline the problem is occurring, I am opening this PR to bring attention to this problem and begin solving it with your help.